### PR TITLE
(maint) Update clj-parent to 7.1.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [puppetlabs/stockpile "0.0.4"]
                  [clj-time]]
 
-  :parent-project {:coords [puppetlabs/clj-parent "7.0.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "7.1.0"]
                    :inherit [:managed-dependencies]}
 
   :profiles {:defaults {:source-paths ["dev"]


### PR DESCRIPTION
clj-parent 7.1.0 updates snakeyaml to 2.0 from 1.3.3 to address CVE-2022-1471.